### PR TITLE
Allow AWS IDs and region to be overridden

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -1,16 +1,15 @@
 service: doing-api
+variablesResolutionMode: 20210326
 
 custom:
   serverless-layers:
     dependenciesPath: ./package.json
-    layersDeploymentBucket: "lcs-layers"
+    layersDeploymentBucket: ${env:SERVERLESS_LAYERS_BUCKET, 'lcs-layers'}
   env: ${lower(${opt:stage, self:provider.stage})}
   vpcSettings:
     prod:
-      securityGroupIds:
-        - sg-052314a1eec2f2567
-      subnetIds:
-        - subnet-01a6b61d749d10c46
+      securityGroupIds: ${split(${env:SECURITY_GROUP_IDS, 'sg-052314a1eec2f2567'}, ',')}
+      subnetIds: ${split(${env:SUBNET_IDS, 'subnet-01a6b61d749d10c46'}, ',')}
     current: ${ternary( ${self:custom.env}, prod, ${self:custom.vpcSettings.prod}, ~ )}
 
 provider:
@@ -18,9 +17,9 @@ provider:
   runtime: nodejs18.x
   memorySize: 1024
   timeout: 10
-  region: us-east-2
+  region: ${env:AWS_REGION, 'us-east-2'}
   iam:
-    role: arn:aws:iam::428019619026:role/ChurchAppsRole
+    role: arn:aws:iam::${aws:accountId}:role/ChurchAppsRole
   environment:
     APP_ENV: ${self:custom.env}
 


### PR DESCRIPTION
Work in support of automated AWS deploy
https://github.com/ChurchApps/ChurchAppsSupport/issues/507

- Use $AWS_REGION from the environment.
- Dynamically find the AWS account ID. Replaces hard-coded account ID.
- Read $SERVERLESS_LAYERS_BUCKET, $SECURITY_GROUP_IDS, and $SUBNET_IDS from the environment. The latter two can be a single ID or a comma-separated list of IDs.

`variablesResolutionMode: 20210326` was added to
make the `${aws:accountId}` lookup work.

I could not find any docs for serverless v2, and
LLMs were not helpful. I had to resort to trial
and error to find a working method of adding
configurable values. Env vars are the only thing
I found that worked.